### PR TITLE
Add support for Shenango's event loop

### DIFF
--- a/CMake/folly-deps.cmake
+++ b/CMake/folly-deps.cmake
@@ -156,7 +156,7 @@ list(APPEND FOLLY_LINK_LIBRARIES /proj/quic-server-PG0/users/saubhik/caladan/lib
 list(APPEND FOLLY_LINK_LIBRARIES /proj/quic-server-PG0/users/saubhik/caladan/libbase.a)
 
 # need to set the linker script
-set(CMAKE_EXE_LINKER_FLAGS "-T /proj/quic-server-PG0/users/saubhik/caladan/base/base.ld")
+set(CMAKE_EXE_LINKER_FLAGS -T /proj/quic-server-PG0/users/saubhik/caladan/base/base.ld)
 
 # message(STATUS "FOLLY_LINK_LIBRARIES: ${FOLLY_LINK_LIBRARIES}")
 # message(STATUS "FOLLY_INCLUDE_DIRECTORIES: ${FOLLY_INCLUDE_DIRECTORIES}")

--- a/CMake/folly-deps.cmake
+++ b/CMake/folly-deps.cmake
@@ -155,8 +155,10 @@ list(APPEND FOLLY_LINK_LIBRARIES /proj/quic-server-PG0/users/saubhik/caladan/lib
 list(APPEND FOLLY_LINK_LIBRARIES /proj/quic-server-PG0/users/saubhik/caladan/libnet.a)
 list(APPEND FOLLY_LINK_LIBRARIES /proj/quic-server-PG0/users/saubhik/caladan/libbase.a)
 
+list(APPEND FOLLY_LINK_LIBRARIES /usr/local/lib/libfmt.a)
+
 # need to set the linker script
-set(CMAKE_EXE_LINKER_FLAGS -T /proj/quic-server-PG0/users/saubhik/caladan/base/base.ld)
+set(CMAKE_EXE_LINKER_FLAGS "-T /proj/quic-server-PG0/users/saubhik/caladan/base/base.ld")
 
 # message(STATUS "FOLLY_LINK_LIBRARIES: ${FOLLY_LINK_LIBRARIES}")
 # message(STATUS "FOLLY_INCLUDE_DIRECTORIES: ${FOLLY_INCLUDE_DIRECTORIES}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -764,7 +764,7 @@ if (BUILD_TESTS)
       # TEST DelayedDestructionTest SOURCES DelayedDestructionTest.cpp
       # TEST DelayedDestructionBaseTest SOURCES DelayedDestructionBaseTest.cpp
       # TEST DestructorCheckTest SOURCES DestructorCheckTest.cpp
-      TEST EventBaseTest SOURCES EventBaseTest.cpp
+      # TEST EventBaseTest SOURCES EventBaseTest.cpp
       # TEST EventBaseLocalTest SOURCES EventBaseLocalTest.cpp
       # TEST HHWheelTimerTest SOURCES HHWheelTimerTest.cpp
       # TEST HHWheelTimerSlowTests SLOW

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -757,6 +757,8 @@ if (BUILD_TESTS)
           #EventHandlerTest.cpp
           # The async signal handler is not supported on Windows.
           #AsyncSignalHandlerTest.cpp
+      # TEST EventHandlerTest SOURCES EventHandlerTest.cpp
+      TEST ShenangoEventHandlerTest SOURCES ShenangoEventHandlerTest.cpp
       # TEST async_timeout_test SOURCES AsyncTimeoutTest.cpp
       # TEST AsyncUDPSocketTest SOURCES AsyncUDPSocketTest.cpp
       # TEST DelayedDestructionTest SOURCES DelayedDestructionTest.cpp

--- a/folly/io/async/EventBase.h
+++ b/folly/io/async/EventBase.h
@@ -34,6 +34,7 @@
 #include <glog/logging.h>
 
 #include "thread.h"
+#include "sh_event.h"
 
 #include <folly/Executor.h>
 #include <folly/Function.h>
@@ -55,6 +56,7 @@
 
 namespace folly {
 class EventBaseBackendBase;
+class ShenangoEventBaseBackendBase;
 
 using Cob = Func; // defined in folly/Executor.h
 
@@ -717,11 +719,13 @@ class EventBase : public TimeoutManager,
   }
 
   EventBaseBackendBase* getBackend() { return evb_.get(); }
+  ShenangoEventBaseBackendBase* getShenangoBackend() { return sevb_.get(); }
   // --------- interface to underlying libevent base ------------
   // Avoid using these functions if possible.  These functions are not
   // guaranteed to always be present if we ever provide alternative EventBase
   // implementations that do not use libevent internally.
   event_base* getLibeventBase() const;
+  rt::EventLoop* getShenangoEventBase() const;
 
   static const char* getLibeventVersion();
   static const char* getLibeventMethod();
@@ -964,7 +968,7 @@ class EventBase : public TimeoutManager,
 
   // pointer to underlying backend class doing the heavy lifting
   std::unique_ptr<EventBaseBackendBase> evb_;
-  std::unique_ptr<EventBaseBackendBase> sevb_; // for shenango event loop
+  std::unique_ptr<ShenangoEventBaseBackendBase> sevb_; // for shenango event loop
 };
 
 template <typename T>

--- a/folly/io/async/EventBase.h
+++ b/folly/io/async/EventBase.h
@@ -964,6 +964,7 @@ class EventBase : public TimeoutManager,
 
   // pointer to underlying backend class doing the heavy lifting
   std::unique_ptr<EventBaseBackendBase> evb_;
+  std::unique_ptr<EventBaseBackendBase> sevb_; // for shenango event loop
 };
 
 template <typename T>

--- a/folly/io/async/EventBaseBackendBase.h
+++ b/folly/io/async/EventBaseBackendBase.h
@@ -18,6 +18,8 @@
 
 #include <memory>
 
+#include "net.h"
+
 #include <folly/io/async/EventUtil.h>
 #include <folly/net/NetOps.h>
 #include <folly/portability/Event.h>
@@ -180,7 +182,8 @@ class EventBaseBackendBase {
   EventBaseBackendBase(const EventBaseBackendBase&) = delete;
   EventBaseBackendBase& operator=(const EventBaseBackendBase&) = delete;
 
-  virtual event_base* getEventBase() = 0;
+  virtual event_base* getEventBase() { return nullptr; };
+  virtual rt::EventLoop* getShenangoEventBase() { return nullptr; };
   virtual int eb_event_base_loop(int flags) = 0;
   virtual int eb_event_base_loopbreak() = 0;
 

--- a/folly/io/async/EventBaseBackendBase.h
+++ b/folly/io/async/EventBaseBackendBase.h
@@ -182,8 +182,7 @@ class EventBaseBackendBase {
   EventBaseBackendBase(const EventBaseBackendBase&) = delete;
   EventBaseBackendBase& operator=(const EventBaseBackendBase&) = delete;
 
-  virtual event_base* getEventBase() { return nullptr; };
-  virtual rt::EventLoop* getShenangoEventBase() { return nullptr; };
+  virtual event_base* getEventBase() = 0;
   virtual int eb_event_base_loop(int flags) = 0;
   virtual int eb_event_base_loopbreak() = 0;
 

--- a/folly/io/async/ShenangoEventBaseBackendBase.cpp
+++ b/folly/io/async/ShenangoEventBaseBackendBase.cpp
@@ -1,0 +1,35 @@
+#include <folly/io/async/ShenangoEventBaseBackendBase.h>
+#include <folly/io/async/EventBase.h>
+
+namespace folly {
+void ShenangoEventBaseEvent::eb_ev_base(EventBase* evb) {
+  evb_ = evb;
+  if (evb) {
+    event_->SetEventLoop(evb->getShenangoEventBase());
+  } else {
+    event_->SetEventLoop(nullptr);
+  }
+}
+
+void ShenangoEventBaseEvent::eb_event_base_set(EventBase* evb) {
+  evb_ = evb;
+  auto* base = evb_ ? (evb_->getShenangoEventBase()) : nullptr;
+  if (base) {
+    event_->SetEventLoop(base);
+  }
+}
+
+void ShenangoEventBaseEvent::eb_event_add(const struct timeval* timeout) {
+  auto* backend = evb_ ? (evb_->getShenangoBackend()) : nullptr;
+  if (backend) {
+    backend->eb_event_add(*this, timeout);
+  }
+}
+
+void ShenangoEventBaseEvent::eb_event_del() {
+  auto* backend = evb_ ? (evb_->getShenangoBackend()) : nullptr;
+  if (backend) {
+    backend->eb_event_del(*this);
+  }
+}
+} // namespace folly

--- a/folly/io/async/ShenangoEventBaseBackendBase.h
+++ b/folly/io/async/ShenangoEventBaseBackendBase.h
@@ -9,46 +9,56 @@ class EventBase;
 class ShenangoEventBaseEvent {
  public:
   ShenangoEventBaseEvent() = default;
+
   ~ShenangoEventBaseEvent() {
     if (userData_ && freeFn_) {
       freeFn_(userData_);
     }
   }
 
-  ShenangoEventBaseEvent(const ShenangoEventBaseEvent&) = delete;
-  ShenangoEventBaseEvent& operator=(const ShenangoEventBaseEvent&) =  delete;
+  ShenangoEventBaseEvent(const ShenangoEventBaseEvent &) = delete;
 
-  typedef void (*FreeFunction)(void* userData);
+  ShenangoEventBaseEvent &operator=(const ShenangoEventBaseEvent &) = delete;
 
-  rt::Event* getEvent() const { return event_; }
+  typedef void (*FreeFunction)(void *userData);
+
+  rt::Event *getEvent() const { return event_; }
+
   bool isEventRegistered() const { return event_->IsEventRegistered(); }
 
-  void* getUserData() { return userData_; }
-  void setUserData(void* userData) { userData_ = userData; }
-  void setUserData(void* userData, FreeFunction freeFn) {
+  void *getUserData() { return userData_; }
+
+  void setUserData(void *userData) { userData_ = userData; }
+
+  void setUserData(void *userData, FreeFunction freeFn) {
     userData_ = userData;
     freeFn_ = freeFn;
   }
 
   void eb_event_set(
-      rt::UdpConn* sock,
+      rt::UdpConn *sock,
       short events,
-      void (*callback)(void*),
-      void* arg) {
+      void (*callback)(void *),
+      void *arg) {
     event_ = rt::Event::CreateEvent(sock, events, callback, arg);
   }
 
   rt::UdpConn* eb_ev_fd() const { return event_->GetSocket(); }
-  void eb_ev_base(EventBase* evb);
+
+  void eb_ev_base(EventBase *evb);
+
   EventBase* eb_ev_base() const { return evb_; }
-  void eb_event_base_set(EventBase* evb);
-  void eb_event_add(const struct timeval* timeout);
+
+  void eb_event_base_set(EventBase *evb);
+
+  void eb_event_add(const struct timeval *timeout);
+
   void eb_event_del();
 
  protected:
-  rt::Event* event_{nullptr};
-  EventBase* evb_{nullptr};
-  void* userData_{nullptr};
+  rt::Event *event_{nullptr};
+  EventBase *evb_{nullptr};
+  void *userData_{nullptr};
   FreeFunction freeFn_{nullptr};
 };
 
@@ -56,22 +66,24 @@ class ShenangoEventBaseBackendBase {
  public:
   using Event = ShenangoEventBaseEvent;
   using FactoryFunc =
-      std::function<std::unique_ptr<folly::EventBaseBackendBase>()>;
+  std::function<std::unique_ptr<folly::EventBaseBackendBase>()>;
 
   ShenangoEventBaseBackendBase() = default;
+
   virtual ~ShenangoEventBaseBackendBase() = default;
 
-  ShenangoEventBaseBackendBase(const ShenangoEventBaseBackendBase&) = delete;
-  ShenangoEventBaseBackendBase& operator=(const ShenangoEventBaseBackendBase&) = delete;
+  ShenangoEventBaseBackendBase(const ShenangoEventBaseBackendBase &) = delete;
 
-  virtual rt::EventLoop* getEventBase() = 0;
+  ShenangoEventBaseBackendBase &
+  operator=(const ShenangoEventBaseBackendBase &) = delete;
+
+  virtual rt::EventLoop *getEventBase() = 0;
+
   virtual void eb_event_base_loop(int flags) = 0;
-  // virtual int eb_event_base_loopbreak() = 0;
 
-  virtual void eb_event_add(Event& event, const struct timeval* timeout) = 0;
-  virtual void eb_event_del(Event& event) = 0;
+  virtual void eb_event_add(Event &event, const struct timeval *timeout) = 0;
 
-  // virtual bool eb_event_active(Event& event, int res) = 0;
+  virtual void eb_event_del(Event &event) = 0;
 };
 
 } // namespace folly

--- a/folly/io/async/ShenangoEventBaseBackendBase.h
+++ b/folly/io/async/ShenangoEventBaseBackendBase.h
@@ -1,0 +1,75 @@
+#include "sh_event.h"
+
+#include <folly/io/async/EventBaseBackendBase.h>
+
+namespace folly {
+
+class EventBase;
+
+class ShenangoEventBaseEvent {
+ public:
+  ShenangoEventBaseEvent() = default;
+  ~ShenangoEventBaseEvent() {
+    if (userData_ && freeFn_) {
+      freeFn_(userData_);
+    }
+  }
+
+  ShenangoEventBaseEvent(const ShenangoEventBaseEvent&) = delete;
+  ShenangoEventBaseEvent& operator=(const ShenangoEventBaseEvent&) =  delete;
+
+  typedef void (*FreeFunction)(void* userData);
+
+  rt::Event* getEvent() const { return event_; }
+  bool isEventRegistered() const { return event_->IsEventRegistered(); }
+
+  void* getUserData() { return userData_; }
+  void setUserData(void* userData) { userData_ = userData; }
+  void setUserData(void* userData, FreeFunction freeFn) {
+    userData_ = userData;
+    freeFn_ = freeFn;
+  }
+
+  void eb_event_set(
+      rt::UdpConn* sock,
+      short events,
+      void (*callback)(void*),
+      void* arg) {
+    event_ = rt::Event::CreateEvent(sock, events, callback, arg);
+  }
+
+  void eb_ev_base(EventBase* evb);
+  void eb_event_base_set(EventBase* evb);
+  void eb_event_add(const struct timeval* timeout);
+  void eb_event_del();
+
+ protected:
+  rt::Event* event_{nullptr};
+  EventBase* evb_{nullptr};
+  void* userData_{nullptr};
+  FreeFunction freeFn_{nullptr};
+};
+
+class ShenangoEventBaseBackendBase {
+ public:
+  using Event = ShenangoEventBaseEvent;
+  using FactoryFunc =
+      std::function<std::unique_ptr<folly::EventBaseBackendBase>()>;
+
+  ShenangoEventBaseBackendBase() = default;
+  virtual ~ShenangoEventBaseBackendBase() = default;
+
+  ShenangoEventBaseBackendBase(const ShenangoEventBaseBackendBase&) = delete;
+  ShenangoEventBaseBackendBase& operator=(const ShenangoEventBaseBackendBase&) = delete;
+
+  virtual rt::EventLoop* getEventBase() = 0;
+  virtual void eb_event_base_loop(int flags) = 0;
+  // virtual int eb_event_base_loopbreak() = 0;
+
+  virtual void eb_event_add(Event& event, const struct timeval* timeout) = 0;
+  virtual void eb_event_del(Event& event) = 0;
+
+  // virtual bool eb_event_active(Event& event, int res) = 0;
+};
+
+} // namespace folly

--- a/folly/io/async/ShenangoEventBaseBackendBase.h
+++ b/folly/io/async/ShenangoEventBaseBackendBase.h
@@ -38,7 +38,9 @@ class ShenangoEventBaseEvent {
     event_ = rt::Event::CreateEvent(sock, events, callback, arg);
   }
 
+  rt::UdpConn* eb_ev_fd() const { return event_->GetSocket(); }
   void eb_ev_base(EventBase* evb);
+  EventBase* eb_ev_base() const { return evb_; }
   void eb_event_base_set(EventBase* evb);
   void eb_event_add(const struct timeval* timeout);
   void eb_event_del();

--- a/folly/io/async/ShenangoEventHandler.h
+++ b/folly/io/async/ShenangoEventHandler.h
@@ -1,0 +1,76 @@
+extern "C" {
+#include "runtime/poll.h"
+}
+
+#include "net.h"
+
+#include <folly/io/async/ShenangoEventBaseBackendBase.h>
+
+namespace folly {
+
+class EventBase;
+
+class ShenangoEventHandler {
+ public:
+  enum ShenangoEventFlags {
+    NONE = 0,
+    TIMEOUT = SEV_TIMEOUT,
+    READ = SEV_READ,
+    WRITE = SEV_WRITE,
+    SIGNAL = SEV_SIGNAL,
+    PERSIST = SEV_PERSIST,
+    ET = SEV_ET,
+  };
+
+  explicit ShenangoEventHandler(EventBase* eventBase = nullptr, rt::UdpConn* sock = nullptr);
+
+  ShenangoEventHandler(const ShenangoEventHandler&) = delete;
+  ShenangoEventHandler& operator=(const ShenangoEventHandler&) = delete;
+
+  virtual ~ShenangoEventHandler();
+
+  virtual void handlerReady(uint16_t events) noexcept = 0;
+  bool registerHandler(uint16_t events) { return registerImpl(events, false); }
+  void unregisterHandler();
+  bool isHandlerRegistered() const { return event_.isEventRegistered(); };
+  void attachEventBase(EventBase* eventBase);
+  void detachEventBase();
+  void initHandler(EventBase* eventBase, rt::UdpConn* sock);
+  uint16_t getRegisteredEvents() const;
+  bool registerInternalHandler(uint16_t events) { return registerImpl(events, true); }
+  bool isPending() const;
+
+ private:
+  bool registerImpl(uint16_t events, bool internal);
+  void ensureNotRegistered(const char* fn);
+  void setEventBase(EventBase* eventBase);
+  static sh_event_callback_fn callbackFn;
+
+  ShenangoEventBaseBackendBase::Event event_;
+  EventBase* eventBase_;
+};
+
+ShenangoEventHandler::ShenangoEventHandler(EventBase* eventBase, rt::UdpConn* sock) {
+  event_.eb_event_set(sock, 0, &callbackFn, this);
+  if (eventBase != nullptr) {
+    setEventBase(eventBase);
+  } else {
+    event_.eb_ev_base(nullptr);
+    eventBase_ = nullptr;
+  }
+}
+
+ShenangoEventHandler::~ShenangoEventHandler() { unregisterHandler(); }
+
+void ShenangoEventHandler::unregisterHandler() {
+  if (isHandlerRegistered()) {
+    event_.eb_event_del();
+  }
+}
+
+void ShenangoEventHandler::setEventBase(EventBase* eventBase) {
+  event_.eb_event_base_set(eventBase);
+  eventBase_ = eventBase;
+}
+
+} // namespace folly

--- a/folly/io/async/ShenangoEventHandler.h
+++ b/folly/io/async/ShenangoEventHandler.h
@@ -7,6 +7,7 @@ extern "C" {
 #include <cassert>
 
 #include <folly/io/async/ShenangoEventBaseBackendBase.h>
+#include <folly/io/async/EventBase.h>
 
 namespace folly {
 
@@ -24,36 +25,46 @@ class ShenangoEventHandler {
     ET = SEV_ET,
   };
 
-  explicit ShenangoEventHandler(EventBase* eventBase = nullptr, rt::UdpConn* sock = nullptr);
+  explicit ShenangoEventHandler(EventBase *eventBase = nullptr,
+                                rt::UdpConn *sock = nullptr);
 
-  ShenangoEventHandler(const ShenangoEventHandler&) = delete;
-  ShenangoEventHandler& operator=(const ShenangoEventHandler&) = delete;
+  ShenangoEventHandler(const ShenangoEventHandler &) = delete;
+
+  ShenangoEventHandler &operator=(const ShenangoEventHandler &) = delete;
 
   virtual ~ShenangoEventHandler();
 
-  virtual void handlerReady(uint16_t events) noexcept = 0;
+  virtual void handlerReady() noexcept = 0;
+
   bool registerHandler(uint16_t events) { return registerImpl(events); }
+
   void unregisterHandler();
+
   bool isHandlerRegistered() const { return event_.isEventRegistered(); };
-  void attachEventBase(EventBase* eventBase);
+
+  void attachEventBase(EventBase *eventBase);
+
   void detachEventBase();
-  void initHandler(EventBase* eventBase, rt::UdpConn* sock);
-  uint16_t getRegisteredEvents() const;
-  bool isPending() const;
+
+  void initHandler(EventBase *eventBase, rt::UdpConn *sock);
 
  private:
   bool registerImpl(uint16_t events);
-  void ensureNotRegistered(const char* fn);
-  void setEventBase(EventBase* eventBase);
-  static sh_event_callback_fn callbackFn;
+
+  void ensureNotRegistered(const char *fn);
+
+  void setEventBase(EventBase *eventBase);
+
+  static void shenangoEventCallback(void *arg);
 
   ShenangoEventBaseBackendBase::Event event_;
-  EventBase* eventBase_;
+  EventBase *eventBase_;
 };
 
-ShenangoEventHandler::ShenangoEventHandler(EventBase* eventBase, rt::UdpConn* sock) {
+ShenangoEventHandler::ShenangoEventHandler(EventBase *eventBase,
+                                           rt::UdpConn *sock) {
   // Currently, event flags are not used inside shenango.
-  event_.eb_event_set(sock, 0, &callbackFn, this);
+  event_.eb_event_set(sock, 0, &shenangoEventCallback, this);
   if (eventBase != nullptr) {
     setEventBase(eventBase);
   } else {
@@ -65,9 +76,30 @@ ShenangoEventHandler::ShenangoEventHandler(EventBase* eventBase, rt::UdpConn* so
 ShenangoEventHandler::~ShenangoEventHandler() { unregisterHandler(); }
 
 bool ShenangoEventHandler::registerImpl(uint16_t events) {
+  // No need to update flags using events,
+  // as shenango does not use flags for now.
   assert(event_.eb_ev_base() != nullptr);
 
-  // No need to update flags using events, as shenango does not use flags for now.
+  // Add the event.
+  //
+  // Although libevent allows events to wait on both I/O and a timeout,
+  // we intentionally don't allow an EventHandler to also use a timeout.
+  // Callers must maintain a separate AsyncTimeout object if they want a
+  // timeout.
+  //
+  // Otherwise, it is difficult to handle persistent events properly.  (The I/O
+  // event and timeout may both fire together the same time around the event
+  // loop.  Normally we would want to inform the caller of the I/O event first,
+  // then the timeout.  However, it is difficult to do this properly since the
+  // I/O callback could delete the EventHandler.)  Additionally, if a caller
+  // uses the same struct event for both I/O and timeout, and they just want to
+  // reschedule the timeout, libevent currently makes an epoll_ctl() call even
+  // if the I/O event flags haven't changed.  Using a separate event struct is
+  // therefore slightly more efficient in this case (although it does take up
+  // more space).
+  event_.eb_event_add(nullptr);
+
+  return true;
 }
 
 void ShenangoEventHandler::unregisterHandler() {
@@ -76,9 +108,61 @@ void ShenangoEventHandler::unregisterHandler() {
   }
 }
 
-void ShenangoEventHandler::setEventBase(EventBase* eventBase) {
+void ShenangoEventHandler::attachEventBase(EventBase *eventBase) {
+  // attachEventBase() may only be called on detached handlers
+  assert(event_.eb_ev_base() == nullptr);
+  assert(!isHandlerRegistered());
+  // This must be invoked from the EventBase's thread
+  eventBase->dcheckIsInEventBaseThread();
+
+  setEventBase(eventBase);
+}
+
+void ShenangoEventHandler::detachEventBase() {
+  ensureNotRegistered(__func__);
+  event_.eb_ev_base(nullptr);
+}
+
+void
+ShenangoEventHandler::initHandler(EventBase *eventBase, rt::UdpConn *sock) {
+  ensureNotRegistered(__func__);
+  event_.eb_event_set(sock, 0, &shenangoEventCallback, this);
+  setEventBase(eventBase);
+}
+
+void ShenangoEventHandler::ensureNotRegistered(const char *fn) {
+  // Neither the EventBase nor file descriptor may be changed while the
+  // handler is registered.  Treat it as a programmer bug and abort the program
+  // if this requirement is violated.
+  if (isHandlerRegistered()) {
+    LOG(ERROR) << fn << " called on registered handler; aborting";
+    abort();
+  }
+}
+
+void ShenangoEventHandler::setEventBase(EventBase *eventBase) {
   event_.eb_event_base_set(eventBase);
   eventBase_ = eventBase;
+}
+
+void
+ShenangoEventHandler::shenangoEventCallback(void *arg) {
+  VLOG(11) << "ShenangoEventHandler::shenangoEventCallback() called!";
+  auto handler = reinterpret_cast<ShenangoEventHandler *>(arg);
+
+  auto observer = handler->eventBase_->getExecutionObserver();
+  if (observer) {
+    observer->starting(reinterpret_cast<uintptr_t>(handler));
+  }
+
+  // this can't possibly fire if handler->eventBase_ is nullptr
+  handler->eventBase_->bumpHandlingTime();
+
+  handler->handlerReady();
+
+  if (observer) {
+    observer->stopped(reinterpret_cast<uintptr_t>(handler));
+  }
 }
 
 } // namespace folly

--- a/folly/io/async/test/ShenangoEventHandlerTest.cpp
+++ b/folly/io/async/test/ShenangoEventHandlerTest.cpp
@@ -4,37 +4,80 @@ extern "C" {
 
 #include "net.h"
 #include "runtime.h"
+#include "timer.h"
 
 #include <iostream>
 
 #include <folly/io/async/EventBase.h>
+#include <folly/io/async/ShenangoEventHandler.h>
 
 namespace {
 
 netaddr raddr;
 constexpr int port = 8000;
 
-//class ShenangoEventHandlerMock : public ShenangoEventHandler {
-// public:
-//  ShenangoEventHandlerMock(folly::EventBase *eb, rt::UdpConn* sock)
-//    : ShenangoEventHandler(eb, sock) {}
-//  void handlerReady(uint16_t /* events */) noexcept override {
-//    // sock->ReadFrom();
-//  }
-//};
+class ShenangoEventHandlerMock : public folly::ShenangoEventHandler {
+ public:
+  ShenangoEventHandlerMock(folly::EventBase* eb, rt::UdpConn* sock)
+      : ShenangoEventHandler(eb, sock), sock_(sock) {
+    sock_->SetNonblocking(true);
+  };
 
-void ServerHandler(void *arg) {
+ private:
+  void handlerReady() noexcept override {
+    int rcv;
+
+    // Make sure to drain the queue as a callback might be executed
+    // after multiple triggers.
+    while (true) {
+      ssize_t ret = sock_->ReadFrom(&rcv, sizeof(rcv), &raddr);
+      if (ret != static_cast<ssize_t>(sizeof(rcv))) {
+        return;
+      }
+      log_info("Received %d in handlerReady() call!", rcv);
+    }
+  }
+
+  rt::UdpConn* sock_;
+};
+
+void ServerHandler(void* arg) {
   rt::UdpConn* sock = rt::UdpConn::Listen({0, port});
   if (!sock) panic("couldn't listen for connections");
 
   folly::EventBase eb;
-  //ShenangoEventHandlerMock eh(&eb, &sock);
-  //eh.registerHandler(ShenangoEventHandler::READ);
+  ShenangoEventHandlerMock eh(&eb, sock);
+
+  eh.registerHandler(
+      folly::ShenangoEventHandler::READ | folly::ShenangoEventHandler::PERSIST);
+
+  log_info("Press return after client is finished");
+  getchar();
+
+  eb.loop();
+
+  sock->Shutdown();
 }
 
-void ClientHandler(void *arg) {}
+void ClientHandler(void* arg) {
+  rt::UdpConn* sock = rt::UdpConn::Dial({0, 0}, raddr);
+  if (unlikely(sock == nullptr)) panic("couldn't connect to raddr!");
 
-int StringToAddr(const char *str, uint32_t *addr) {
+  int snd = 100;
+  for (int i = 0; i < 10; ++i) {
+    ssize_t ret = sock->Write(&snd, sizeof(snd));
+    if (ret != static_cast<ssize_t>(sizeof(snd))) {
+      panic("write failed, ret = %ld", ret);
+    }
+
+    ++snd;
+    rt::Sleep(1 * rt::kSeconds);
+  }
+
+  sock->Shutdown();
+}
+
+int StringToAddr(const char* str, uint32_t* addr) {
   uint8_t a, b, c, d;
   if (sscanf(str, "%hhu.%hhu.%hhu.%hhu", &a, &b, &c, &d) != 4)
     return -EINVAL;
@@ -44,7 +87,7 @@ int StringToAddr(const char *str, uint32_t *addr) {
 }
 } // anonymous namespace
 
-int main(int argc, char *argv[]) {
+int main(int argc, char* argv[]) {
   int ret;
 
   if (argc < 3) {

--- a/folly/io/async/test/ShenangoEventHandlerTest.cpp
+++ b/folly/io/async/test/ShenangoEventHandlerTest.cpp
@@ -1,0 +1,84 @@
+extern "C" {
+#include <base/log.h>
+}
+
+#include "net.h"
+#include "runtime.h"
+
+#include <iostream>
+
+#include <folly/io/async/EventBase.h>
+
+namespace {
+
+netaddr raddr;
+constexpr int port = 8000;
+
+//class ShenangoEventHandlerMock : public ShenangoEventHandler {
+// public:
+//  ShenangoEventHandlerMock(folly::EventBase *eb, rt::UdpConn* sock)
+//    : ShenangoEventHandler(eb, sock) {}
+//  void handlerReady(uint16_t /* events */) noexcept override {
+//    // sock->ReadFrom();
+//  }
+//};
+
+void ServerHandler(void *arg) {
+  rt::UdpConn* sock = rt::UdpConn::Listen({0, port});
+  if (!sock) panic("couldn't listen for connections");
+
+  folly::EventBase eb;
+  //ShenangoEventHandlerMock eh(&eb, &sock);
+  //eh.registerHandler(ShenangoEventHandler::READ);
+}
+
+void ClientHandler(void *arg) {}
+
+int StringToAddr(const char *str, uint32_t *addr) {
+  uint8_t a, b, c, d;
+  if (sscanf(str, "%hhu.%hhu.%hhu.%hhu", &a, &b, &c, &d) != 4)
+    return -EINVAL;
+
+  *addr = MAKE_IP_ADDR(a, b, c, d);
+  return 0;
+}
+} // anonymous namespace
+
+int main(int argc, char *argv[]) {
+  int ret;
+
+  if (argc < 3) {
+    std::cerr << "usage: [cfg_file] [cmd] ..." << std::endl;
+    return -EINVAL;
+  }
+
+  std::string cmd = argv[2];
+  if (cmd == "server") {
+    ret = runtime_init(argv[1], ServerHandler, NULL);
+    if (ret) {
+      printf("failed to start runtime\n");
+      return ret;
+    }
+  } else if (cmd != "client") {
+    std::cerr << "invalid command: " << cmd << std::endl;
+    return -EINVAL;
+  }
+
+  if (argc < 4) {
+    std::cerr << "usage: [cfg_file] client [remote_ip]" << std::endl;
+    return -EINVAL;
+  }
+
+  ret = StringToAddr(argv[3], &raddr.ip);
+  if (ret)
+    return -EINVAL;
+  raddr.port = port;
+
+  ret = runtime_init(argv[1], ClientHandler, NULL);
+  if (ret) {
+    printf("failed to start runtime\n");
+    return ret;
+  }
+
+  return 0;
+}


### PR DESCRIPTION
Add's the necessary stuff to use Shenango's eventing framework:
- `ShenangoEventBaseBackendBase`
- `ShenangoEventBaseBackend`
- `ShenangoEventBaseEvent`
- `ShenangoEventHandler`

Tests:
- `ShenangoEventHandlerTest.cpp` will be the ultimate integration test for the event handler functionality

Corresponding Shenango PR: https://github.com/saubhik/caladan/pull/9